### PR TITLE
Convert to using the Composer plugin API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
 # ApplyPatches
 
-A Composer post-update/install-cmd script to automatically apply patches located, 
-by default, in mysite/patches (obviously, based on an SS layout). This 
-can be altered by setting the `marketo_patch_dir` environment variable. 
+A Composer post-update/install-cmd script to automatically apply patches located,
+by default, in mysite/patches (obviously, based on an SS layout). This
+can be altered by setting the `marketo_patch_dir` environment variable.
 
 ## Install instructions
 
-### Add it to your project with:
 
-`composer require marketo/composer-patch-applicator`
-
-### Add the following to your composer.json
-
-```
-"scripts": {
-     "post-update-cmd": "Marketo\\CliTools\\ApplyPatches::run",
-     "post-install-cmd": "Marketo\\CliTools\\ApplyPatches::run"
+1. `composer require marketo/composer-patch-applicator`
+2. Configure your patch directory (if needed). You can do this either by setting
+   the `marketo_patch_dir` environment variable, or by adding this to your `composer.json`:
+   ```
+"extra": {
+  "marketo_patch_dir": "path/to/your/patch/dir"
 }
-```
+   ```

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "marketo/composer-patch-applicator",
   "description": "A Composer post-update/install-cmd script to automatically apply patches",
-  
+
   "authors":
   [
     {
@@ -9,19 +9,29 @@
       "email": "marcus@silverstripe.com.au"
     }
   ],
-  
+
   "support":
   {
     "issues": "https://github.com/Marketo/Composer-PatchApplicator/issues"
   },
-  
+
   "license" : "BSD-3-Clause",
-  
+
   "autoload":
   {
     "psr-0":
     {
-    "Marketo\\": "src/"
+      "Marketo\\": "src/"
     }
+  },
+
+  "extra":
+  {
+    "class": "Marketo\\CliTools\\ApplyPatches"
+  },
+  
+  "require":
+  {
+    "composer-plugin-api": "~1.1"
   }
 }


### PR DESCRIPTION
Saves your users some time, as they'll just have to `require` this plugin. Also adds support for setting the marketo patch dir in the `extra` section of a user's root `composer.json`.
